### PR TITLE
Setup autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Prerequisites
 You have to have a few packages installed on your Ubuntu box to take advantage of this indicator.
 Make sure you have the NVIDIA driver >=331.20 installed and the additional package called "nvidia-prime".
 In case the indicator doesn't start because it is missing the python module "appindicator",
-again, make sure to install missing packages. To install all needed dependencies:
+again, make sure to install missing packages. If the indicator contains a glxinfo error message, you are missing the mesa-utils package. To install all needed dependencies:
 
-sudo apt-get install nvidia-prime nvidia-331 nvidia-settings python-appindicator
+sudo apt-get install nvidia-prime nvidia-331 nvidia-settings python-appindicator mesa-utils
 
 
 How to install

--- a/setup.sh
+++ b/setup.sh
@@ -37,6 +37,13 @@ else
 	chmod 644 /etc/sudoers.d/prime-indicator-sudoers
 
 	read -n1 -p "Autostart PRIME Indicator? (y/N) "
-	echo
-	[[ $REPLY = [yY] ]] && cp prime-indicator.desktop $HOME/.config/autostart/ || { rm $HOME/.config/autostart/prime-indicator.desktop; }
+	echo $USER
+	if [[ $REPLY == [yY] ]]; then
+		mkdir -p $HOME/.config/autostart
+		cp prime-indicator.desktop $HOME/.config/autostart
+        chown $SUDO_USER:$SUDO_USER $HOME/.config/autostart
+        chown $SUDO_USER:$SUDO_USER $HOME/.config/autostart/prime-indicator.desktop
+	else
+		rm -f $HOME/.config/autostart/prime-indicator.desktop
+	fi
 fi


### PR DESCRIPTION
The setup script failed for me on a clean Ubuntu installation because the $HOME/.config/autostart directory didn't exist. The glxinfo binary used by the indicator is in the mesa-utils package which isn't installed by default, so it should be added to the list of prerequisits.
