### PR TITLE
Fixed misspelling of logout text. Added Cancel button

### DIFF
--- a/prime-indicator
+++ b/prime-indicator
@@ -71,7 +71,7 @@ class PRIMEIndicator:
 	os.system("/usr/bin/nvidia-settings")
 
     def showRebootDialog(self):
-	message = "You will be logouted now."
+	message = "You will be logged out now."
 	dialog = gtk.MessageDialog(None, gtk.DIALOG_MODAL, gtk.MESSAGE_INFO,
                                        gtk.BUTTONS_NONE, message)
 	dialog.set_deletable(False)

--- a/prime-indicator
+++ b/prime-indicator
@@ -60,12 +60,13 @@ class PRIMEIndicator:
 	self.menu.append(self.settings_item)
 
     def switch(self, dude):
-	self.showRebootDialog()
-	if self.isIntegrated:
-	    self.switchToDiscrete()
-	else:
-	    self.switchToIntegrated()
-	self.logout()
+	response = self.showRebootDialog()
+	if response != gtk.RESPONSE_CANCEL:
+	  if self.isIntegrated:
+	      self.switchToDiscrete()
+	  else:
+	      self.switchToIntegrated()
+	  self.logout()
 
     def opensettings(self, dude):
 	os.system("/usr/bin/nvidia-settings")
@@ -77,8 +78,10 @@ class PRIMEIndicator:
 	dialog.set_deletable(False)
 	dialog.connect('delete_event', self.ignore)
 	dialog.add_button(gtk.STOCK_OK, gtk.RESPONSE_OK)
+	dialog.add_button(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL)
 	response = dialog.run()
 	dialog.destroy()
+	return response
 
     def ignore(*args):
 	return gtk.TRUE


### PR DESCRIPTION
Just quickly changed the logout text for readability. Also added button for cancellation of "Quick Switch". I found that I kept accidentally clicking this instead of the "NVIDIA Settings" option if I wasn't paying attention and there was no way to back out of it.